### PR TITLE
Allow subtypes in type comparison for data-events

### DIFF
--- a/src/main/kotlin/io/github/frantoso/jasm/Action.kt
+++ b/src/main/kotlin/io/github/frantoso/jasm/Action.kt
@@ -1,6 +1,7 @@
 package io.github.frantoso.jasm
 
 import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
 
 /**
  * The interface an action must provide.
@@ -74,7 +75,7 @@ class DataAction<T : Any>(
             return
         }
 
-        if (dataEvent.data::class != dataType) {
+        if (!dataEvent.data::class.isSubclassOf(dataType)) {
             fire(null)
             return
         }

--- a/src/test/kotlin/io/github/frantoso/jasm/ActionTests.kt
+++ b/src/test/kotlin/io/github/frantoso/jasm/ActionTests.kt
@@ -40,6 +40,16 @@ class ActionTests {
         }
 
         @Test
+        fun `executes the action (derived data type)`() {
+            var counter = 1
+            val action = DataAction(Number::class) { data -> if (data != null) counter += data.toInt() }
+
+            action.fire(dataEvent<StartEvent, Int>(3))
+
+            assertThat(counter).isEqualTo(4)
+        }
+
+        @Test
         fun `executes the action with null as parameter (no data event)`() {
             var counter = 1
             var dataProvided: Any? = 2


### PR DESCRIPTION
Comes in handy when passing args to entry functions, e.g. for chaining events: 
```kotlin

      val firstState = State("StartState")
      val secondState = State("StateWithEntryAction")

      fun triggerReturnToFirst(stopEvent: Event?) {
          if (stopEvent != null) fsm.triggerEvent(stopEvent)
      }

      sealed class CustomEvents : Event() {
          data object Start : CustomEvents()

          data object Stop : CustomEvents()

          data object StartThenStop : DataEvent<CustomEvents>(Start, Stop::class)
      }

      val fms =
          fsmOf(
              "ExampleFsm",
              firstState
                  .transition<CustomEvents.Start>(secondState),
              secondState
                  .entry<CustomEvents> { triggerReturnToFirst(stopEvent = it) }
                  .transition<CustomEvents.Stop>(firstState),
          )
```
